### PR TITLE
Deprecate workspace tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Integration.app Workspace Import/Export Tool
 
-This CLI tool allows you to export and import data from Integration.app Workspaces, facilitating easier management and migration of workspace configurations.
+> ⚠️ **DEPRECATED**: This tool has been deprecated. Please use the official [Membrane CLI](https://www.npmjs.com/package/@integration-app/membrane-cli) instead, which provides enhanced functionality and better support for workspace management.
+
+This repository is archived and no longer maintained. For the latest workspace management tools and features, please refer to the [Membrane CLI documentation](https://www.npmjs.com/package/@integration-app/membrane-cli).
 
 ## Features
 


### PR DESCRIPTION
## Summary by Sourcery

Deprecate the workspace tools and recommend the use of the Membrane CLI instead. Archive the repository to prevent further use.

Chores:
- Deprecate the workspace tools.
- Archive the repository.